### PR TITLE
Add the discovery application with proxy handler

### DIFF
--- a/asabdiscovery/__init__.py
+++ b/asabdiscovery/__init__.py
@@ -1,0 +1,6 @@
+from .app import ASABDiscoveryApplication
+
+
+__all__ = [
+	"ASABDiscoveryApplication"
+]

--- a/asabdiscovery/app.py
+++ b/asabdiscovery/app.py
@@ -12,7 +12,7 @@ from .proxy.handler import ProxyWebHandler
 
 asab.Config.add_defaults({
 	"web": {
-		"listen": "8959",  # Well-known port of asab discovery
+		"listen": "8998",  # Well-known port of asab discovery
 	},
 	"auth": {
 		"public_keys_url": "http://seacat-auth.service_id.asab/.well-known/jwks.json"

--- a/asabdiscovery/app.py
+++ b/asabdiscovery/app.py
@@ -1,0 +1,67 @@
+import asab.api
+import asab.web
+import asab.web.rest
+import asab.zookeeper
+import asab.proactor
+import asab.metrics
+
+import asab.api.discovery
+
+from .proxy.handler import ProxyWebHandler
+
+
+asab.Config.add_defaults({
+	"web": {
+		"listen": "8959",  # Well-known port of asab discovery
+	},
+	"auth": {
+		"public_keys_url": "http://seacat-auth.service_id.asab/.well-known/jwks.json"
+	},
+})
+
+
+class ASABDiscoveryApplication(asab.Application):
+
+	def __init__(self):
+		super().__init__(modules=[
+			asab.proactor.Module,
+			asab.web.Module,
+			asab.zookeeper.Module,
+			asab.metrics.Module,
+		])
+
+
+	async def initialize(self):
+		# Initialize the web service
+		self.WebService = self.get_service("asab.WebService")
+		self.WebContainer = asab.web.WebContainer(self.WebService, "web")
+		self.WebContainer.WebApp.middlewares.append(asab.web.rest.JsonExceptionMiddleware)
+
+		self.ProactorService = self.get_service("asab.ProactorService")
+
+		# Initialize Sentry.io
+		if asab.Config.has_section("sentry"):
+			import asab.sentry as asab_sentry
+			self.SentryService = asab_sentry.SentryService(self)
+
+		# Initialize ZooKeeper Service
+		if 'zookeeper' in asab.Config.sections():
+			self.ZooKeeperService = self.get_service("asab.ZooKeeperService")
+			self.ZooKeeperContainer = asab.zookeeper.ZooKeeperContainer(self.ZooKeeperService, 'zookeeper')
+
+		else:
+			self.ZooKeeperContainer = None
+
+		# Initialize API service
+		self.ASABApiService = asab.api.ApiService(self)
+		self.ASABApiService.initialize_web(self.WebContainer)
+		self.ASABApiService.initialize_zookeeper(self.ZooKeeperContainer)
+
+		# Initialize authorization
+		self.AuthService = asab.web.auth.AuthService(self)
+
+		# Get the discovery service
+		self.DiscoveryService = self.get_service("asab.DiscoveryService")
+
+		# Initialize handlers
+		self.ProxyWebHandler = ProxyWebHandler(self, self.DiscoveryService)

--- a/asabdiscovery/proxy/__init__.py
+++ b/asabdiscovery/proxy/__init__.py
@@ -1,0 +1,6 @@
+from .handler import ProxyWebHandler
+
+
+__all__ = [
+	"ProxyWebHandler",
+]

--- a/asabdiscovery/proxy/handler.py
+++ b/asabdiscovery/proxy/handler.py
@@ -1,0 +1,85 @@
+import logging
+
+import aiohttp
+import aiohttp.web
+import asab.web.auth
+
+import asab.web.rest
+
+#
+
+L = logging.getLogger(__name__)
+
+#
+
+
+class ProxyWebHandler:
+
+	def __init__(self, app, discovery_service):
+		self.App = app
+		self.DiscoveryService = discovery_service
+
+		web_app = app.WebContainer.WebApp
+
+		# Add the proxy endpoint(s)
+		# Example: /~/service_id/<service_id>/<tenant>/<object>/<method>
+		web_app.router.add_route(
+			'*',  # Accept all HTTP methods (GET, POST, etc.)
+			r"/~/{key}/{value}/{proxy_path:.*}",
+			self.proxy_by_key,
+		)
+
+
+	async def proxy_by_key(self, request):
+		key = request.match_info["key"]
+		value = request.match_info["value"]
+		proxy_path = request.match_info["proxy_path"]
+
+		# Locate URLs using the key-value pair
+		# TODO: Is this safe?
+		urls = await self.DiscoveryService.locate(**{key: value})
+
+		if not urls:
+			return asab.web.rest.json_response(
+				request, {"result": "NOT-FOUND"}, status=404
+			)
+
+		# Extract request details
+		method = request.method
+		query_params = request.query_string
+		body = await request.read()
+		headers = {key: value for key, value in request.headers.items()}
+
+		# Forward the request to the first available URL
+		for url in urls:
+			url_with_endpoint = f"{url}/{proxy_path}"
+
+			if query_params:
+				url_with_endpoint = f"{url_with_endpoint}?{query_params}"
+
+			try:
+
+				async with aiohttp.ClientSession() as session:
+					async with session.request(
+						method=method,
+						url=url_with_endpoint,
+						headers=headers,
+						data=body,
+					) as resp:
+
+						# Forward the response back to the client
+						payload = await resp.read()
+
+						return aiohttp.web.Response(
+							body=payload,  # Use the raw payload as the body
+							status=resp.status,  # Forward the status code from the proxied response
+							headers=resp.headers,  # Forward the headers from the proxied response
+						)
+
+			except aiohttp.client_exceptions.ClientConnectorError:
+				# If this url could not be connected to, try another one
+				continue
+
+		return asab.web.rest.json_response(
+			request, {"result": "NOT-FOUND"}, status=404
+		)


### PR DESCRIPTION
This is the lightweight proxy service that redirects request to instances discovered by DiscoveryService of ASAB.

Example request

```
GET  /~/service_id/<service_id>/<tenant>/<object>/<method>
```